### PR TITLE
Fix equipment cost schema date coercion

### DIFF
--- a/apps/api/app/api/[[...route]]/expenses-equipment-cost.ts
+++ b/apps/api/app/api/[[...route]]/expenses-equipment-cost.ts
@@ -12,7 +12,7 @@ const updateEquipmentSchema = z.object({
   amount: z.number().optional(),
   rank: z.number().optional(),
   category: z.string().optional(),
-  purchaseDate: z.date().optional(),
+  purchaseDate: z.coerce.date().optional(),
   usage: z.number().optional(),
   lifeSpan: z.number().optional(),
 });
@@ -23,7 +23,7 @@ const createEquipmentSchema = z.object({
   amount: z.number(),
   rank: z.number(),
   category: z.string(),
-  purchaseDate: z.date(),
+  purchaseDate: z.coerce.date(),
   usage: z.number(),
   lifeSpan: z.number(),
 });


### PR DESCRIPTION
## Summary
- coerce equipment cost payload purchase dates from JSON strings into Date objects to prevent validation failures

## Testing
- pnpm lint --filter api *(fails: Next.js lint prompts for interactive config and exits with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68e3e880ef6c832194bceabfa61f1ac9