### PR TITLE
Fix break-even calculations with margin and deductions

### DIFF
--- a/apps/app/app/features/feature-billable-cost/index.tsx
+++ b/apps/app/app/features/feature-billable-cost/index.tsx
@@ -155,7 +155,7 @@ export const BillableCosts = ({ userId }: { userId: string }) => {
     (data: BillableCostsForm): Calculations => {
       const timeOff = data.holiday_days + data.vacation_days + data.sick_leave;
       const workDaysPerYear = data.work_days * 52;
-      const actualWorkDays = workDaysPerYear - timeOff;
+      const actualWorkDays = Math.max(workDaysPerYear - timeOff, 0);
       const billableHours = actualWorkDays * data.hours_per_day;
 
       return {

--- a/apps/app/app/features/feature-hourly-cost/node-view/index.tsx
+++ b/apps/app/app/features/feature-hourly-cost/node-view/index.tsx
@@ -91,7 +91,7 @@ export const NodeView = ({ userId, expenses }: NodeViewProps) => {
     // Calculate all metrics once
     const timeOff = data.holiday_days + data.vacation_days + data.sick_leave;
     const workDaysPerYear = data.work_days * 52;
-    const actualWorkDays = workDaysPerYear - timeOff;
+    const actualWorkDays = Math.max(workDaysPerYear - timeOff, 0);
     const billableHours = actualWorkDays * data.hours_per_day;
 
     const breakEvenMetrics = useBreakEvenCalculator({

--- a/apps/app/hooks/use-break-even-calculator.ts
+++ b/apps/app/hooks/use-break-even-calculator.ts
@@ -1,5 +1,3 @@
-import { useMemo } from "react";
-
 interface BreakEvenInput {
   billableHours: number;
   monthlySalary: number;
@@ -19,10 +17,6 @@ interface BreakEvenCalculations {
   monthlyRate: number;
 }
 
-const calculateTaxes = (totalExpenses: number, taxRate: number): number => {
-  return (totalExpenses * taxRate) / 100;
-};
-
 const roundToTwoDecimals = (value: number): number => {
   return Math.round(value * 100) / 100;
 };
@@ -41,23 +35,36 @@ export const useBreakEvenCalculator = (
     workDays,
   } = input;
 
-  const yearlySalary = monthlySalary * 12;
-  const totalYearlyExpenses = totalExpensesCostPerMonth * 12;
-  const totalExpenses = yearlySalary + totalYearlyExpenses;
+  const safeBillableHours = Math.max(billableHours, 0);
 
-  const totalYearlyTaxes = calculateTaxes(totalExpenses, taxRate);
-  const totalYearlyCosts =
-    yearlySalary + totalYearlyTaxes + totalYearlyExpenses;
+  if (safeBillableHours === 0) {
+    return {
+      breakEven: 0,
+      hourlyRate: 0,
+      dayRate: 0,
+      weekRate: 0,
+      monthlyRate: 0,
+    };
+  }
 
-  const baseHourlyRate = totalYearlyCosts / billableHours;
-  const marginMultiplier = 1 + margin / 100;
-  const hourlyRate = baseHourlyRate * marginMultiplier;
+  const yearlySalary = Math.max(monthlySalary, 0) * 12;
+  const totalYearlyExpenses = Math.max(totalExpensesCostPerMonth, 0) * 12;
+  const baseYearlyCosts = yearlySalary + totalYearlyExpenses;
+
+  const marginMultiplier = 1 + Math.max(margin, 0) / 100;
+  const costsWithMargin = baseYearlyCosts * marginMultiplier;
+
+  const deductionRate = Math.min(Math.max(taxRate + fees, 0) / 100, 0.99);
+  const netRevenueFactor = 1 - deductionRate;
+
+  const grossYearlyRevenue = costsWithMargin / netRevenueFactor;
+  const hourlyRate = grossYearlyRevenue / safeBillableHours;
   const dayRate = hourlyRate * hoursPerDay;
   const weekRate = dayRate * workDays;
-  const monthlyRate = (hourlyRate * billableHours) / 12;
+  const monthlyRate = grossYearlyRevenue / 12;
 
   return {
-    breakEven: roundToTwoDecimals(totalYearlyCosts),
+    breakEven: roundToTwoDecimals(grossYearlyRevenue),
     hourlyRate: roundToTwoDecimals(hourlyRate),
     dayRate: roundToTwoDecimals(dayRate),
     weekRate: roundToTwoDecimals(weekRate),


### PR DESCRIPTION
## Summary
- gross up yearly costs for taxes, fees, and margin when computing break-even metrics
- handle zero billable hours and clamp work day totals so calculations never go negative

## Testing
- pnpm lint *(fails: Next.js ESLint prompt requires interactive selection)*

------
https://chatgpt.com/codex/tasks/task_e_68e3ec2a903c8321ab36a15045203ca5